### PR TITLE
add glibc 2.38 to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ below.
 
 - [.NET 9.0 Preview 6 or later](https://dotnet.microsoft.com/en-us/download/dotnet/9.0)
 - [Spin 2.7.0 or later](https://github.com/fermyon/spin/releases/tag/v2.7.0)
+- glibc 2.38 or later (available on Ubuntu 24.04 - see
+  [dotnet/runtimelab#2605](https://github.com/dotnet/runtimelab/pull/2605))
 
 Also, we need to download a few pre-release packages and tell NuGet where to
 find them.  Set `platform=linux-arm64`, `platform=linux-x64`,


### PR DESCRIPTION
If you compile a project with an older version of glibc (such as Ubuntu 22.04), you're met with this error:

```
$ spin build
Building component hello with `dotnet publish -o build App.csproj`
Restore complete (1.7s)
You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
  App failed with 1 error(s) (0.4s) → bin/Release/net9.0/wasi-wasm/App.dll
    /home/bacongobbler/code/github.com/dicej/spin-dotnet-sdk/samples/http-hello/.packages/microsoft.dotnet.ilcompiler.llvm/9.0.0-dev/build/Microsoft.NETCore.Native.targets(354,5): error MSB3073: The command ""/home/bacongobbler/code/github.com/dicej/spin-dotnet-sdk/samples/http-hello/.packages/runtime.linux-x64.microsoft.dotnet.ilcompiler.llvm/9.0.0-dev/tools/ilc" @"obj/Release/net9.0/wasi-wasm/native/App.ilc.rsp"" exited with code 1.

Build failed with 1 error(s) in 2.2s
Error: Build command for component hello failed with status Exited(1)

$ .packages/runtime.linux-x64.microsoft.dotnet.ilcompiler.llvm/9.0.0-dev/tools/ilc obj/Release/net9.0/wasi-wasm/native/App.ilc.rsp 
.packages/runtime.linux-x64.microsoft.dotnet.ilcompiler.llvm/9.0.0-dev/tools/ilc: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by .packages/runtime.linux-x64.microsoft.dotnet.ilcompiler.llvm/9.0.0-dev/tools/ilc)
```