### PR TITLE
add packages to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ obj
 build
 artifacts
 .spin
+packages


### PR DESCRIPTION
This way nobody's accidentally including the local nuget packages in their commits as described in the "Getting Started" section of the README

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>