### PR TITLE
WIP: Change namespace to `Fermyon.Spin`

### DIFF
--- a/Spin.SDK.csproj
+++ b/Spin.SDK.csproj
@@ -6,13 +6,13 @@
     <PackageVersion>$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
     <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts/</PackageOutputPath>
     <IsPackable>false</IsPackable>
-    <PackageId>Fermyon.Spin.SDK</PackageId>
+    <PackageId>Fermyon.Spin</PackageId>
     <Authors>Fermyon Engineering</Authors>
     <Description>SDK for creating Spin applications using .NET</Description>
     <RepositoryUrl>https://github.com/fermyon/spin-dotnet-sdk</RepositoryUrl>
     <PackageLicenseExpression>Apache-2.0 WITH LLVM-exception</PackageLicenseExpression>
     <PackageTags>webassembly, wasm, spin</PackageTags>
-    
+
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Spin.SDK</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -26,7 +26,7 @@
       <_PackageFiles Include="build/**" BuildAction="Content" PackagePath="build" />
       <_PackageFiles Include="src/SpinHttpWorld_component_type.wit" BuildAction="Content" PackagePath="." />
       <_PackageFiles Include="src/SpinHttpWorld.wit.exports.wasi.http.v0_2_0.IIncomingHandler.cs" BuildAction="Content" PackagePath="." />
-      <_PackageFiles Include="src/SpinHttpWorld.wit.exports.wasi.http.v0_2_0.IncomingHandlerInterop.cs" BuildAction="Content" PackagePath="." />      
+      <_PackageFiles Include="src/SpinHttpWorld.wit.exports.wasi.http.v0_2_0.IncomingHandlerInterop.cs" BuildAction="Content" PackagePath="." />
     </ItemGroup>
   </Target>
 
@@ -34,6 +34,6 @@
     <Compile Remove="src/SpinHttpWorld.wit.exports.wasi.http.v0_2_0.IIncomingHandler.cs" />
     <Compile Remove="src/SpinHttpWorld.wit.exports.wasi.http.v0_2_0.IncomingHandlerInterop.cs" />
     <Compile Remove="samples/**" />
-  </ItemGroup>  
-  
+  </ItemGroup>
+
 </Project>

--- a/src/InputStream.cs
+++ b/src/InputStream.cs
@@ -1,7 +1,7 @@
 using SpinHttpWorld;
 using SpinHttpWorld.wit.imports.wasi.io.v0_2_0;
 
-namespace Spin.Http;
+namespace Fermyon.Spin.Http;
 
 public class InputStream : Stream
 {

--- a/src/KeyValue/KeyValue.cs
+++ b/src/KeyValue/KeyValue.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.KeyValue;
+namespace Fermyon.Spin.KeyValue;
 
 public class Store
 {

--- a/src/KeyValue/KeyValue.cs
+++ b/src/KeyValue/KeyValue.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SDK.KeyValue;
+namespace Spin.KeyValue;
 
 public class Store
 {
@@ -13,7 +13,7 @@ public class Store
     }
 
     private const string DEFAULT_STORE_NAME = "default";
-    
+
     public static Store Open(string name)
     {
         var inner = SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0.IKeyValue.Store.Open(name);

--- a/src/LLM/Inferencing.cs
+++ b/src/LLM/Inferencing.cs
@@ -1,7 +1,7 @@
 using System.Formats.Asn1;
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SDK.LLM;
+namespace Spin.LLM;
 
 public class Inferencing
 {

--- a/src/LLM/Inferencing.cs
+++ b/src/LLM/Inferencing.cs
@@ -1,7 +1,7 @@
 using System.Formats.Asn1;
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.LLM;
+namespace Fermyon.Spin.LLM;
 
 public class Inferencing
 {

--- a/src/LLM/InferencingParams.cs
+++ b/src/LLM/InferencingParams.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SDK.LLM;
+namespace Spin.LLM;
 
 public class InferencingParams
 {

--- a/src/LLM/InferencingParams.cs
+++ b/src/LLM/InferencingParams.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.LLM;
+namespace Fermyon.Spin.LLM;
 
 public class InferencingParams
 {

--- a/src/LLM/Model.cs
+++ b/src/LLM/Model.cs
@@ -1,4 +1,4 @@
-namespace Spin.LLM;
+namespace Fermyon.Spin.LLM;
 
 public readonly struct Model(string name)
 {

--- a/src/LLM/Model.cs
+++ b/src/LLM/Model.cs
@@ -1,4 +1,4 @@
-namespace Spin.SDK.LLM;
+namespace Spin.LLM;
 
 public readonly struct Model(string name)
 {

--- a/src/LLM/Models.cs
+++ b/src/LLM/Models.cs
@@ -1,4 +1,4 @@
-namespace Spin.SDK.LLM;
+namespace Spin.LLM;
 
 public static class Models
 {

--- a/src/LLM/Models.cs
+++ b/src/LLM/Models.cs
@@ -1,4 +1,4 @@
-namespace Spin.LLM;
+namespace Fermyon.Spin.LLM;
 
 public static class Models
 {

--- a/src/MQTT/MQTT.cs
+++ b/src/MQTT/MQTT.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SDK.MQTT;
+namespace Spin.MQTT;
 
 public class Connection: IDisposable
 {
@@ -9,7 +9,7 @@ public class Connection: IDisposable
     {
         _connection = IMqtt.Connection.Open(address, username, password, keepAlive);
     }
-    
+
     public static Connection Open(string address, string username, string password, ulong keepAliveIntervalInSecs)
     {
         return new Connection(address, username, password, keepAliveIntervalInSecs);
@@ -33,7 +33,7 @@ public class Connection: IDisposable
 
 public enum Qos
 {
-    AT_MOST_ONCE, 
-    AT_LEAST_ONCE, 
+    AT_MOST_ONCE,
+    AT_LEAST_ONCE,
     EXACTLY_ONCE
 }

--- a/src/MQTT/MQTT.cs
+++ b/src/MQTT/MQTT.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.MQTT;
+namespace Fermyon.Spin.MQTT;
 
 public class Connection: IDisposable
 {

--- a/src/OutputStream.cs
+++ b/src/OutputStream.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.wasi.io.v0_2_0;
 
-namespace Spin.Http;
+namespace Fermyon.Spin.Http;
 
 public class OutputStream : Stream
 {

--- a/src/RequestHandler.cs
+++ b/src/RequestHandler.cs
@@ -3,7 +3,7 @@ using SpinHttpWorld;
 using SpinHttpWorld.wit.imports.wasi.http.v0_2_0;
 using SpinHttpWorld.wit.imports.wasi.io.v0_2_0;
 
-namespace Spin.Http;
+namespace Fermyon.Spin.Http;
 
 public class RequestHandler
 {

--- a/src/SQLite/Connection.cs
+++ b/src/SQLite/Connection.cs
@@ -1,17 +1,17 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SDK.SQLite;
+namespace Spin.SQLite;
 
 public class Connection: IDisposable
 {
     private const string DEFAULT_DATABASE_NAME = "default";
     private readonly ISqlite.Connection _connection;
-    
+
     private Connection(ISqlite.Connection connection)
     {
         _connection = connection;
     }
-    
+
     public static Connection Open(string databaseName)
     {
         return new Connection(ISqlite.Connection.Open(databaseName));

--- a/src/SQLite/Connection.cs
+++ b/src/SQLite/Connection.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SQLite;
+namespace Fermyon.Spin.SQLite;
 
 public class Connection: IDisposable
 {

--- a/src/SQLite/QueryResult.cs
+++ b/src/SQLite/QueryResult.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SDK.SQLite;
+namespace Spin.SQLite;
 
 public class QueryResult
 {
@@ -12,7 +12,7 @@ public class QueryResult
         Rows = rows;
         Columns = columns;
     }
-    
+
     internal static QueryResult From(ISqlite.QueryResult result)
     {
         return new QueryResult(result.rows.Select(RowResult.From).ToList(), result.columns);

--- a/src/SQLite/QueryResult.cs
+++ b/src/SQLite/QueryResult.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SQLite;
+namespace Fermyon.Spin.SQLite;
 
 public class QueryResult
 {

--- a/src/SQLite/RowResult.cs
+++ b/src/SQLite/RowResult.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SDK.SQLite;
+namespace Spin.SQLite;
 
 public class RowResult
 {

--- a/src/SQLite/RowResult.cs
+++ b/src/SQLite/RowResult.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SQLite;
+namespace Fermyon.Spin.SQLite;
 
 public class RowResult
 {

--- a/src/SQLite/Value.cs
+++ b/src/SQLite/Value.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SDK.SQLite;
+namespace Spin.SQLite;
 
 public class Value
 {
@@ -16,12 +16,12 @@ public class Value
             _ => FromNull()
         };
     }
-    
+
     internal ISqlite.Value Actual { get; }
 
     public byte Tag => Actual.Tag;
     public bool IsNull => Actual.Tag == ISqlite.Value.NULL;
-    
+
     public long AsInteger() => Actual.AsInteger;
     public double AsDouble() => Actual.AsReal;
     public string AsText() => Actual.AsText;
@@ -31,7 +31,7 @@ public class Value
     {
         Actual = actual;
     }
-    
+
     public static Value FromInteger(long value)
     {
         return new Value(ISqlite.Value.integer(value));
@@ -41,17 +41,17 @@ public class Value
     {
         return new Value(ISqlite.Value.text(value));
     }
-    
+
     public static Value FromDouble(double value)
     {
         return new Value(ISqlite.Value.real(value));
     }
-    
+
     public static Value FromBlob(byte[] value)
     {
         return new Value(ISqlite.Value.blob(value));
     }
-    
+
     public static Value FromNull()
     {
         return new Value(ISqlite.Value.@null());

--- a/src/SQLite/Value.cs
+++ b/src/SQLite/Value.cs
@@ -1,6 +1,6 @@
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SQLite;
+namespace Fermyon.Spin.SQLite;
 
 public class Value
 {

--- a/src/Variables.cs
+++ b/src/Variables.cs
@@ -1,7 +1,7 @@
 using SpinHttpWorld;
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.SDK;
+namespace Spin.Variables;
 
 public class Variables
 {

--- a/src/Variables.cs
+++ b/src/Variables.cs
@@ -1,7 +1,7 @@
 using SpinHttpWorld;
 using SpinHttpWorld.wit.imports.fermyon.spin.v2_0_0;
 
-namespace Spin.Variables;
+namespace Fermyon.Spin.Variables;
 
 public class Variables
 {

--- a/src/WasiEventLoop.cs
+++ b/src/WasiEventLoop.cs
@@ -1,7 +1,7 @@
 using System.Runtime.CompilerServices;
 using SpinHttpWorld.wit.imports.wasi.io.v0_2_0;
 
-namespace Spin.Http;
+namespace Fermyon.Spin.Http;
 
 internal static class WasiEventLoop
 {


### PR DESCRIPTION
As a general convention, it's good practice to append the company/org name in the package name so that the library does not conflict with other packages.

The Spin Web Framework has already claimed the namespace on nuget.org: https://www.nuget.org/packages/Spin

Additionally, some packages were referred to as `Spin.SDK.*` while some were referred to as `Spin.*`; for example `Spin.Http` and `Spin.SDK.MQTT`. This change consolidates them all under `Fermyon.Spin.*`.