### PR TITLE
build and release tags to github/nuget

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup dotnet
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
 
       - run: dotnet pack  --configuration Release
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: Publish NuGet packages
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup dotnet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 9.0.x
+
+      - run: dotnet pack  --configuration Release
+
+      - name: Publish to GitHub Packages
+        run: |
+          for nupkg in $(find . -name *.nupkg)
+          do
+            dotnet nuget push $nupkg --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate
+          done
+
+      # - name: Publish to nuget.org
+      #   run: |
+      #     for nupkg in $(find . -name *.nupkg)
+      #     do
+      #       dotnet nuget push $nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+      #     done

--- a/Spin.SDK.csproj
+++ b/Spin.SDK.csproj
@@ -7,7 +7,10 @@
     <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts/</PackageOutputPath>
     <IsPackable>false</IsPackable>
     <PackageId>Fermyon.Spin.SDK</PackageId>
+    <OutputType>Library</OutputType>
     <Authors>Fermyon Engineering</Authors>
+    <Company>Fermyon</Company>
+    <Copyright>Fermyon Technologies, Inc. All Rights Reserved.</Copyright>
     <Description>SDK for creating Spin applications using .NET</Description>
     <RepositoryUrl>https://github.com/fermyon/spin-dotnet-sdk</RepositoryUrl>
     <PackageLicenseExpression>Apache-2.0 WITH LLVM-exception</PackageLicenseExpression>


### PR DESCRIPTION
This workflow will compile and release a new package of all generated packages to GitHub Packages when a new tag is released. nuget.org support is possible, but commented out at the moment as it needs a repository secret, and we need to establish a package name that will not conflict with existing packages on nuget.org.