### PR TITLE
Have the samples refer to Spin.SDK.csproj

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [ "*" ]
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Setup NUGET_LOCAL_PATH
+        run: |
+          mkdir packages
+          # TODO: remove this once the samples rely on a local build of the Spin SDK
+          curl -LO --output-dir packages https://github.com/${{ github.repository }}/releases/download/canary/Fermyon.Spin.SDK.0.1.0-dev.nupkg
+          curl -LO --output-dir packages https://github.com/${{ github.repository }}/releases/download/canary/Microsoft.DotNet.ILCompiler.LLVM.9.0.0-dev.nupkg
+          curl -LO --output-dir packages https://github.com/${{ github.repository }}/releases/download/canary/runtime.wasi-wasm.Microsoft.DotNet.ILCompiler.LLVM.9.0.0-dev.nupkg
+          curl -LO --output-dir packages https://github.com/${{ github.repository }}/releases/download/canary/runtime.linux-x64.Microsoft.DotNet.ILCompiler.LLVM.9.0.0-dev.nupkg
+          echo "NUGET_LOCAL_PATH=$(pwd)/packages" >> $GITHUB_ENV
+
+      - run: dotnet build  --configuration Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,8 +20,6 @@ jobs:
       - name: Setup NUGET_LOCAL_PATH
         run: |
           mkdir packages
-          # TODO: remove this once the samples rely on a local build of the Spin SDK
-          curl -LO --output-dir packages https://github.com/${{ github.repository }}/releases/download/canary/Fermyon.Spin.SDK.0.1.0-dev.nupkg
           curl -LO --output-dir packages https://github.com/${{ github.repository }}/releases/download/canary/Microsoft.DotNet.ILCompiler.LLVM.9.0.0-dev.nupkg
           curl -LO --output-dir packages https://github.com/${{ github.repository }}/releases/download/canary/runtime.wasi-wasm.Microsoft.DotNet.ILCompiler.LLVM.9.0.0-dev.nupkg
           curl -LO --output-dir packages https://github.com/${{ github.repository }}/releases/download/canary/runtime.linux-x64.Microsoft.DotNet.ILCompiler.LLVM.9.0.0-dev.nupkg

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ find them.  Set `platform=linux-arm64`, `platform=linux-x64`,
 
 ```
 mkdir packages
-curl -LO --output-dir packages https://github.com/dicej/spin-dotnet-sdk/releases/download/canary/Fermyon.Spin.SDK.0.1.0-dev.nupkg
 curl -LO --output-dir packages https://github.com/dicej/spin-dotnet-sdk/releases/download/canary/Microsoft.DotNet.ILCompiler.LLVM.9.0.0-dev.nupkg
 curl -LO --output-dir packages https://github.com/dicej/spin-dotnet-sdk/releases/download/canary/runtime.wasi-wasm.Microsoft.DotNet.ILCompiler.LLVM.9.0.0-dev.nupkg
 curl -LO --output-dir packages https://github.com/dicej/spin-dotnet-sdk/releases/download/canary/runtime.$platform.Microsoft.DotNet.ILCompiler.LLVM.9.0.0-dev.nupkg

--- a/Spin.SDK.csproj
+++ b/Spin.SDK.csproj
@@ -24,19 +24,33 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <Target Name="PackTaskDependencies" BeforeTargets="GenerateNuspec">
-    <ItemGroup>
-      <_PackageFiles Include="build/**" BuildAction="Content" PackagePath="build" />
-      <_PackageFiles Include="src/SpinHttpWorld_component_type.wit" BuildAction="Content" PackagePath="." />
-      <_PackageFiles Include="src/SpinHttpWorld.wit.exports.wasi.http.v0_2_0.IIncomingHandler.cs" BuildAction="Content" PackagePath="." />
-      <_PackageFiles Include="src/SpinHttpWorld.wit.exports.wasi.http.v0_2_0.IncomingHandlerInterop.cs" BuildAction="Content" PackagePath="." />
-    </ItemGroup>
-  </Target>
+  <ItemGroup>
+    <Compile Remove="samples/**" />
+  </ItemGroup>
 
   <ItemGroup>
+
     <Compile Remove="src/SpinHttpWorld.wit.exports.wasi.http.v0_2_0.IIncomingHandler.cs" />
+    <Content Include="src/SpinHttpWorld.wit.exports.wasi.http.v0_2_0.IIncomingHandler.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>%(Filename)%(Extension)</TargetPath>
+    </Content>
+
     <Compile Remove="src/SpinHttpWorld.wit.exports.wasi.http.v0_2_0.IncomingHandlerInterop.cs" />
-    <Compile Remove="samples/**" />
+    <Content Include="src/SpinHttpWorld.wit.exports.wasi.http.v0_2_0.IncomingHandlerInterop.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>%(Filename)%(Extension)</TargetPath>
+    </Content>
+
+    <Content Include="src/SpinHttpWorld_component_type.wit">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>%(Filename)%(Extension)</TargetPath>
+    </Content>
+
+    <Content Include="build/**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+
   </ItemGroup>
 
 </Project>

--- a/samples/http-aspnetcore/App.csproj
+++ b/samples/http-aspnetcore/App.csproj
@@ -26,9 +26,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fermyon.Spin.SDK" Version="0.1.0-dev" />
     <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="9.0.0-dev" />
     <PackageReference Include="runtime.$(_hostOS)-$(_hostArch).Microsoft.DotNet.ILCompiler.LLVM" Version="9.0.0-dev" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Spin.SDK.csproj" />
   </ItemGroup>
 
   <Target Name="CheckAspNetCoreWasiPath"

--- a/samples/http-hello/App.csproj
+++ b/samples/http-hello/App.csproj
@@ -21,8 +21,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fermyon.Spin.SDK" Version="0.1.0-dev" />
     <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="9.0.0-dev" />
     <PackageReference Include="runtime.$(_hostOS)-$(_hostArch).Microsoft.DotNet.ILCompiler.LLVM" Version="9.0.0-dev" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Spin.SDK.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/http-streams/App.csproj
+++ b/samples/http-streams/App.csproj
@@ -21,8 +21,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fermyon.Spin.SDK" Version="0.1.0-dev" />
     <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="9.0.0-dev" />
     <PackageReference Include="runtime.$(_hostOS)-$(_hostArch).Microsoft.DotNet.ILCompiler.LLVM" Version="9.0.0-dev" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Spin.SDK.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR means we can now create samples straight off any SDK development in-progress. That also means we can ask for samples to be included when new libraries are added to the SDK.