### PR TITLE
fix reference to RegisterWasiPollableHandle

### DIFF
--- a/src/InputStream.cs
+++ b/src/InputStream.cs
@@ -90,7 +90,7 @@ public class InputStream : Stream
                     var buffer = result;
                     if (buffer.Length == 0)
                     {
-                        await WasiEventLoop.Register(stream.Subscribe()).ConfigureAwait(false);
+                        await WasiEventLoop.Register(stream.Subscribe(), cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {

--- a/src/OutputStream.cs
+++ b/src/OutputStream.cs
@@ -76,7 +76,7 @@ public class OutputStream : Stream
             var count = (int)stream.CheckWrite();
             if (count == 0)
             {
-                await WasiEventLoop.Register(stream.Subscribe());
+                await WasiEventLoop.Register(stream.Subscribe(), cancellationToken);
             }
             else if (offset == limit)
             {

--- a/src/WasiEventLoop.cs
+++ b/src/WasiEventLoop.cs
@@ -5,14 +5,14 @@ namespace Spin.Http;
 
 internal static class WasiEventLoop
 {
-    internal static Task Register(IPoll.Pollable pollable)
+    internal static Task Register(IPoll.Pollable pollable, CancellationToken cancellationToken)
     {
         var handle = pollable.Handle;
         pollable.Handle = 0;
-        return CallRegister((Thread)null!, handle);
+        return CallRegister((Thread)null!, handle, cancellationToken);
 
-        [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "RegisterWasiPollable")]
-        static extern Task CallRegister(Thread t, int handle);
+        [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "RegisterWasiPollableHandle")]
+        static extern Task CallRegister(Thread t, int handle, CancellationToken cancellationToken);
     }
 
     internal static void Dispatch()


### PR DESCRIPTION
The name was updated upstream. This will allow the Spin SDK to be compatible with the latest runtimelab package releases.